### PR TITLE
Embed AQI in weather panel and show 5-day forecast

### DIFF
--- a/scal.py
+++ b/scal.py
@@ -281,6 +281,7 @@ def month_filter(items, y, m):
 
 # === [SECTION: Weather (OpenWeatherMap API)] =================================
 _weather_cache = {"key": "", "loc": "", "ts": 0.0, "data": None}
+_air_cache = {"key": "", "loc": "", "ts": 0.0, "data": None}
 
 def _owm_geocode(q, key):
     url = "https://api.openweathermap.org/geo/1.0/direct"
@@ -301,7 +302,7 @@ def _owm_fetch_onecall(lat, lon, key, units):
     js = r.json()
     def icon_url(code): return f"https://openweathermap.org/img/wn/{code}@2x.png"
     cur = js.get("current", {})
-    dailies = (js.get("daily") or [])[:7]
+    dailies = (js.get("daily") or [])[:5]
     cur_data = {"temp": round(cur.get("temp", 0)), "icon": icon_url(cur.get("weather", [{}])[0].get("icon", "01d"))}
     days = []
     for d in dailies:
@@ -362,6 +363,33 @@ def fetch_weather():
     except Exception:
         data = _owm_fetch_fiveday(lat, lon, key, units)
     _weather_cache.update({"key": key, "loc": loc, "ts": now, "data": data})
+    return data
+
+def fetch_air_quality():
+    cfgw = CFG.get("weather", {})
+    key = cfgw.get("api_key", "").strip()
+    loc = cfgw.get("location", "").strip()
+    if not key or not loc:
+        return None
+    now = time.time()
+    cache_ok = (
+        _air_cache["data"] is not None
+        and _air_cache["key"] == key
+        and _air_cache["loc"] == loc
+        and now - _air_cache["ts"] < 600
+    )
+    if cache_ok:
+        return _air_cache["data"]
+    lat, lon = _owm_geocode(loc, key)
+    url = "https://api.openweathermap.org/data/2.5/air_pollution"
+    r = requests.get(url, params={"lat": lat, "lon": lon, "appid": key}, timeout=10)
+    r.raise_for_status()
+    js = r.json()
+    aqi = ((js.get("list") or [{}])[0].get("main") or {}).get("aqi")
+    labels = {1: "Good", 2: "Fair", 3: "Moderate", 4: "Poor", 5: "Very Poor"}
+    colors = {1: "#009966", 2: "#ffde33", 3: "#ff9933", 4: "#cc0033", 5: "#660099"}
+    data = {"aqi": aqi, "label": labels.get(aqi, "?"), "color": colors.get(aqi, "#fff")}
+    _air_cache.update({"key": key, "loc": loc, "ts": now, "data": data})
     return data
 
 # === [SECTION: Bus (Seoul/Gyeonggi) API adapters] ============================
@@ -783,6 +811,14 @@ def api_weather():
     except Exception as e:
         return jsonify({"error": str(e)}), 500
 
+@app.get("/api/air")
+def api_air():
+    try:
+        data = fetch_air_quality()
+        return jsonify(data or {"need_config": True})
+    except Exception as e:
+        return jsonify({"error": str(e)}), 500
+
 @app.get("/api/photos")
 def api_photos():
     return jsonify(list_local_images())
@@ -866,16 +902,15 @@ BOARD_HTML = r"""
   .verse { flex:0 0 100px; display:flex; align-items:flex-start; gap:12px; }
   .verse .text { white-space:pre-wrap; line-height:1.4; font-size:16px; text-shadow:0 0 6px rgba(0,0,0,.65); }
 
-/* Weather layout (card style 7-day forecast) */
+/* Weather layout (card style 5-day forecast) */
 .weather { display:flex; gap:16px; align-items:center; }
-.weather .w-now { display:flex; align-items:center; gap:12px; min-width:180px; }
+.weather .w-now { display:flex; align-items:center; gap:12px; width:180px; flex:0 0 180px; }
 .weather .w-now .temp { font-size:44px; font-weight:800; line-height:1; }
 
 .weather .w-days {
   display:grid;
-  grid-template-columns:repeat(7,1fr);
+  grid-template-columns:repeat(5,105px);
   gap:12px;
-  width:100%;
   align-items:stretch;
 }
 .weather .w-day {
@@ -891,6 +926,21 @@ BOARD_HTML = r"""
 .weather .w-day .temps { display:flex; justify-content:center; gap:8px; font-size:14px; margin-top:4px; }
 .weather .w-day .hi { font-weight:800; font-size:16px; }
 .weather .w-day .lo { opacity:.75; font-size:14px; }
+
+.weather .aqi {
+  display:flex;
+  justify-content:center;
+  align-items:center;
+  text-align:center;
+  background:rgba(0,0,0,.25);
+  border:1px solid rgba(255,255,255,.08);
+  border-radius:12px;
+  padding:10px 6px;
+  min-width:105px;
+  font-size:24px;
+  font-weight:700;
+  text-shadow:0 0 6px rgba(0,0,0,.65);
+}
 
 /* Background must stay behind content */
 .bg, .bg2 { z-index:-1; }
@@ -1004,13 +1054,13 @@ async function loadWeather() {
     t.textContent = data.current.temp + '°';
     now.appendChild(i); now.appendChild(t);
 
-    // 7-day cards (right)
+    // 5-day cards (middle)
     const days = document.createElement('div');
     days.className = 'w-days';
     const names = ['Sun','Mon','Tue','Wed','Thu','Fri','Sat'];
     const todayIso = new Date().toISOString().slice(0,10);
 
-    for (const d of data.days) {
+    for (const d of data.days.slice(0,5)) {
       const dt = new Date(d.date);
 
       const item = document.createElement('div');
@@ -1047,6 +1097,11 @@ async function loadWeather() {
 
     box.appendChild(now);
     box.appendChild(days);
+    const aqi = document.createElement('div');
+    aqi.id = 'aqi';
+    aqi.className = 'aqi';
+    box.appendChild(aqi);
+    loadAQI();
   } catch (e) {
     const box2 = document.getElementById('weather');
     if (box2) box2.textContent = 'Failed to load weather';
@@ -1055,8 +1110,25 @@ async function loadWeather() {
 loadWeather();
 setInterval(loadWeather, 10 * 60 * 1000);
 
-// ===== Weather block (final: card-style 7-day forecast) =====
-// Verse block
+// ===== Air Quality block =====
+async function loadAQI() {
+  const box = document.getElementById('aqi');
+  if (!box) return;
+  try {
+    const r = await fetch('/api/air');
+    const data = await r.json();
+    box.textContent = '';
+    if (data && data.need_config) { box.textContent = 'OWM API Key required'; return; }
+    if (!data || data.error)     { box.textContent = 'AQI error'; return; }
+    box.textContent = 'AQI: ' + data.label;
+    if (data.color) box.style.color = data.color;
+  } catch (e) {
+    box.textContent = 'Failed to load AQI';
+  }
+}
+setInterval(loadAQI, 10 * 60 * 1000);
+
+// ===== Verse block =====
 async function loadVerse(){
   try{
     const r = await fetch('/api/verse');


### PR DESCRIPTION
## Summary
- limit backend and frontend forecast to five days for OpenWeatherMap free tier
- fix layout: current conditions width 180px and five 105px day cards
- move AQI block inside weather container with matching styling

## Testing
- `python -m py_compile scal.py`


------
https://chatgpt.com/codex/tasks/task_e_68b517eedb4c8329a07dca4bbe90ad69