### PR TITLE
Fix bus config indentation

### DIFF
--- a/scal_full_integrated.py
+++ b/scal_full_integrated.py
@@ -31,20 +31,20 @@ todoist:
   api_token: "0aa4d2a4f95e952a1f635c14d6c6ba7e3b26bc2b"
   max_items: 20
 
-  # ===== BusInfo (단일 프로필, 텔레그램에서 station_id 입력) =====
-  bus:
-    region: 'gyeonggi'            # seoul | gyeonggi | incheon
-    seoul:
-      api_key: "3d3d725df7c8daa3445ada3ceb7778d94328541e6eb616f02c0b82cb11ff182f"
-      ars_id: ""        # 서울은 arsId
-    gyeonggi:
-      api_key: "3d3d725df7c8daa3445ada3ceb7778d94328541e6eb616f02c0b82cb11ff182f"
-      station_id: "39516"
-    incheon:
-      api_key: "3d3d725df7c8daa3445ada3ceb7778d94328541e6eb616f02c0b82cb11ff182f"
-      stop_id: ""       # 인천은 bstopId
-    max_items: 8
-    routes_whitelist: []     # ["7016","M7106"] 처럼 문자열로!
+# ===== BusInfo (단일 프로필, 텔레그램에서 station_id 입력) =====
+bus:
+  region: 'gyeonggi'            # seoul | gyeonggi | incheon
+  seoul:
+    api_key: "3d3d725df7c8daa3445ada3ceb7778d94328541e6eb616f02c0b82cb11ff182f"
+    ars_id: ""        # 서울은 arsId
+  gyeonggi:
+    api_key: "3d3d725df7c8daa3445ada3ceb7778d94328541e6eb616f02c0b82cb11ff182f"
+    station_id: "39516"
+  incheon:
+    api_key: "3d3d725df7c8daa3445ada3ceb7778d94328541e6eb616f02c0b82cb11ff182f"
+    stop_id: ""       # 인천은 bstopId
+  max_items: 8
+  routes_whitelist: []     # ["7016","M7106"] 처럼 문자열로!
 """
 # ==== EMBEDDED_CONFIG (YAML) END
 


### PR DESCRIPTION
## Summary
- move bus config block out of todoist section so fetch_bus uses the right API key and stop id

## Testing
- `python - <<'PY'
import scal_full_integrated as m
print(m.fetch_bus())
PY` *(fails: ModuleNotFoundError: No module named 'yaml')*
- `pip install pyyaml` *(fails: Could not find a version that satisfies the requirement pyyaml (Tunnel connection failed: 403 Forbidden))*

------
https://chatgpt.com/codex/tasks/task_e_68b7d99815a88329bd0722def277f9f9