### PR TITLE
Reduce bus section height

### DIFF
--- a/scal_full_integrated.py
+++ b/scal_full_integrated.py
@@ -919,8 +919,8 @@ BOARD_HTML = r"""
 <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no"/>
 <title>Smart Frame</title>
 <style>
-  :root { --W:1080px; --H:1920px; --top:90px; --cal:910px;
-          --bus:290px; --weather:280px; --todo:270px; } /* todo height trimmed */
+  :root { --W:1080px; --H:1848px; --top:90px; --cal:910px;
+          --bus:218px; --weather:280px; --todo:270px; } /* bus box reduced 25% */
 
   /* Global layout */
   html,body { margin:0; padding:0; background:transparent; color:#fff; font-family:system-ui,-apple-system,Roboto,'Noto Sans KR',sans-serif; }


### PR DESCRIPTION
## Summary
- shrink bus section to 75% of its former height
- adjust overall frame height to keep layout aligned

## Testing
- `python -m py_compile scal_full_integrated.py panel/xylopanel/bus.py panel/businfo/xylopanel.py`


------
https://chatgpt.com/codex/tasks/task_e_68b84ca7fbbc8329b0a9846576b6d7fd