### PR TITLE
Show bus stop name on board

### DIFF
--- a/scal_full_integrated.py
+++ b/scal_full_integrated.py
@@ -1063,7 +1063,7 @@ BOARD_HTML = r"""
       </div>
     </div>
     <div class="bus blk">
-      <h3>Bus</h3>
+      <h3 id="bus-title">Bus</h3>
       <div class="rows" id="businfo"></div>
     </div>
     <div class="weather blk" id="weather"></div>
@@ -1281,6 +1281,10 @@ async function refreshBus(){
     const data = await r.json();
     const box = document.getElementById('businfo');
     if(!box) return;
+
+    const title = document.getElementById('bus-title');
+    if(title) title.textContent = data.stop_name ? `Bus - ${data.stop_name}` : 'Bus';
+
     box.innerHTML='';
     if(data.need_config){
       box.textContent = '버스 설정 필요';


### PR DESCRIPTION
## Summary
- display bus stop name in bus block header
- update client script to set stop name while refreshing

## Testing
- `python -m py_compile scal_full_integrated.py`


------
https://chatgpt.com/codex/tasks/task_e_68b85c59a5808329951f66ce668f00e2