### PR TITLE
style: prevent bus info wrapping

### DIFF
--- a/scal_full_integrated.py
+++ b/scal_full_integrated.py
@@ -939,10 +939,10 @@ BOARD_HTML = r"""
   .bus .stop{font-size:14px; margin-bottom:4px;}
   .bus .rows{display:flex; gap:10px; overflow:hidden;}
   .bus .col{flex:1 1 50%; display:flex; flex-direction:column; gap:6px;}
-  .bus .item{display:flex; font-size:14px;}
-  .bus .item .rt{font-weight:700; width:8ch;}
-  .bus .item .hops{width:6ch; text-align:right; margin-right:4px;}
-  .bus .item .msg{flex:1; text-align:right; opacity:.9;}
+  .bus .item{display:flex; font-size:14px; white-space:nowrap;}
+  .bus .item .rt{font-weight:700; width:8ch; white-space:nowrap;}
+  .bus .item .hops{width:6ch; text-align:right; margin-right:4px; white-space:nowrap;}
+  .bus .item .msg{flex:1; text-align:right; opacity:.9; overflow:hidden; text-overflow:ellipsis; white-space:nowrap;}
 
   /* Verse block */
   .verse { flex:0 0 100px; display:flex; flex-direction:column; align-items:flex-start; }


### PR DESCRIPTION
## Summary
- keep bus info lines on a single row by adding `white-space: nowrap`
- truncate overly long status text with ellipsis

## Testing
- `python -m py_compile scal_full_integrated.py`


------
https://chatgpt.com/codex/tasks/task_e_68badf4a6b348329a6bdd47bf1f80c0f