### PR TITLE
Display up to 14 bus arrivals

### DIFF
--- a/scal_full_integrated.py
+++ b/scal_full_integrated.py
@@ -563,7 +563,7 @@ def fetch_bus():
                 "min1": _extract_min_from_msg(tmsg),
             })
         items.sort(key=lambda x: x["min1"] if x["min1"] is not None else 9999)
-        items = items[:8]
+        items = items[:14]
         return {"region": region, "stop_name": stop_name, "stop_id": stop_id, "items": items}
     else:
         lines = tago_stub(stop_id, keys.get("tago", ""), region)


### PR DESCRIPTION
## Summary
- Increase server-side bus arrival limit to display up to 14 routes in the dashboard without changing the bus box height.

## Testing
- `python -m py_compile scal_full_integrated.py bus_bot.py`


------
https://chatgpt.com/codex/tasks/task_e_68baed3654988329a36346f7c61b2926