### PR TITLE
feat: add interactive stop selection

### DIFF
--- a/scal_full_integrated.py
+++ b/scal_full_integrated.py
@@ -1573,7 +1573,7 @@ if TB:
             TB.answer_callback_query(c.id)
             kb = telebot.types.InlineKeyboardMarkup(row_width=1)
             kb.add(
-                telebot.types.InlineKeyboardButton("정류소ID 변경", callback_data="bus_set_stop"),
+                telebot.types.InlineKeyboardButton("정류소 변경", callback_data="bus_set_stop"),
                 telebot.types.InlineKeyboardButton("서비스키 변경", callback_data="bus_set_key"),
                 telebot.types.InlineKeyboardButton("현재설정 조회", callback_data="bus_show_config"),
                 telebot.types.InlineKeyboardButton("지정정류소 현황조회", callback_data="bus_test"),

--- a/tests/test_bus_bot.py
+++ b/tests/test_bus_bot.py
@@ -1,0 +1,20 @@
+import os, sys
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+import bus_bot as bb
+
+
+def test_is_tago_node_id():
+    assert bb.is_tago_node_id("ICB164000104")
+    assert not bb.is_tago_node_id("서울역")
+    assert not bb.is_tago_node_id("ICB12")
+
+
+def test_paginate():
+    items = list(range(25))
+    assert bb.paginate(items, 0, 10) == list(range(10))
+    assert bb.paginate(items, 2, 10) == list(range(20, 25))
+
+
+def test_normalize_arrmsg():
+    assert bb._normalize_arrmsg("", 30) == ("곧 도착", "1정거장")
+    assert bb._normalize_arrmsg("", 180) == ("3분", "1정거장")


### PR DESCRIPTION
## Summary
- add `/stop` command with city and stop selection via inline keyboards
- detect TAGO node IDs and save chosen stop to user session
- rename menu label to "정류소 변경"

## Testing
- `pip install requests python-telegram-bot -q` *(fails: ProxyError 403 Forbidden)*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bc101dded083299b582a77eb3a4a3b