### PR TITLE
Adjust home assistant grid layout and styling

### DIFF
--- a/scal_full_integrated.py
+++ b/scal_full_integrated.py
@@ -1419,8 +1419,8 @@ BOARD_HTML = r"""
   .todo .due { opacity:.9; min-width:50px; margin-right:12px; }
 
   .bus{flex:0 0 var(--bus); display:flex; flex-direction:column;}
-  .bus .split{display:flex; gap:14px; flex:1 1 auto;}
-  .bus .arrivals{flex:1 1 55%; display:flex; flex-direction:column;}
+  .bus .split{display:flex; gap:16px; flex:1 1 auto; align-items:stretch;}
+  .bus .arrivals{flex:1 1 0; display:flex; flex-direction:column; background:rgba(0,0,0,.28); border-radius:12px; padding:12px 14px; border:1px solid rgba(255,255,255,.12); min-width:0;}
   .bus .arrivals h3{margin-bottom:6px;}
   .bus .stop{font-size:14px; margin-bottom:4px;}
   .bus .rows{display:flex; gap:10px; overflow:hidden;}
@@ -1430,14 +1430,14 @@ BOARD_HTML = r"""
   .bus .item .hops{width:6ch; text-align:right; margin-right:4px; white-space:nowrap;}
   .bus .item .msg{flex:0 0 6ch; text-align:right; opacity:.9; overflow:hidden; text-overflow:ellipsis; white-space:nowrap;}
 
-  .bus .ha-panel{flex:1 1 45%; display:flex; flex-direction:column;}
+  .bus .ha-panel{flex:2 1 0; display:flex; flex-direction:column; background:rgba(0,0,0,.28); border-radius:12px; padding:12px 14px; border:1px solid rgba(255,255,255,.12); min-width:0;}
   .bus .ha-panel h3{margin-bottom:6px;}
-  .bus .ha-grid{display:grid; grid-template-columns:repeat(auto-fill,minmax(90px,1fr)); gap:10px; flex:1 1 auto; align-content:start;}
-  .bus .ha-device{display:flex; flex-direction:column; gap:6px; align-items:center; justify-content:center; padding:12px 8px; border-radius:12px; background:rgba(255,255,255,.08); border:1px solid rgba(255,255,255,.12); transition:background .2s, border-color .2s, transform .2s; cursor:pointer; user-select:none;}
-  .bus .ha-device .icon{font-size:30px;}
+  .bus .ha-grid{display:grid; grid-template-columns:repeat(6,minmax(0,1fr)); gap:8px; flex:1 1 auto; align-content:start;}
+  .bus .ha-device{display:flex; flex-direction:column; gap:4px; align-items:center; justify-content:center; padding:10px 6px; border-radius:12px; background:rgba(255,255,255,.08); border:1px solid rgba(255,255,255,.12); transition:background .2s, border-color .2s, box-shadow .2s, transform .2s; cursor:pointer; user-select:none;}
+  .bus .ha-device .icon{font-size:24px;}
   .bus .ha-device .name{font-size:13px; text-align:center; white-space:nowrap; overflow:hidden; text-overflow:ellipsis; width:100%;}
   .bus .ha-device .state{font-size:12px; opacity:.85;}
-  .bus .ha-device.on{background:rgba(255,255,255,.18); border-color:rgba(255,255,255,.28); box-shadow:0 0 14px rgba(255,255,255,.15);}
+  .bus .ha-device.on{background:rgba(255,255,255,.18); border-color:#58ff93; box-shadow:0 0 18px rgba(88,255,147,.45);}
   .bus .ha-device:active{transform:scale(.97);}
 
   /* Verse block */


### PR DESCRIPTION
## Summary
- set the bus arrival and home assistant panels to a 1:2 width ratio with distinct styling
- tune the home assistant grid to show 24 icons in a 6x4 layout with reduced icon sizes
- update the on-state styling to use a bright green border for better visual contrast

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d8d23a35248329864c26b75a290998