### PR TITLE
Adjust board card layout for dashboard sections

### DIFF
--- a/scal_full_integrated.py
+++ b/scal_full_integrated.py
@@ -1658,7 +1658,7 @@ BOARD_HTML = r"""
 <title>Smart Frame</title>
 <style>
   :root { --W:1080px; --H:1828px; --top:70px; --cal:910px;
-          --weather:280px; --layout-left:520px; }
+          --weather:280px; --layout-left:420px; }
 
   /* Global layout */
   html,body { margin:0; padding:0; background:transparent; color:#fff; font-family:system-ui,-apple-system,Roboto,'Noto Sans KR',sans-serif; }
@@ -1693,6 +1693,7 @@ BOARD_HTML = r"""
         white-space:nowrap; overflow:hidden; text-overflow:ellipsis; text-shadow:0 0 6px rgba(0,0,0,.65);}
 
   .section {
+    position:relative;
     height: calc(var(--H) - var(--top) - var(--cal));
     padding:10px 24px;
     box-sizing:border-box;
@@ -1708,25 +1709,37 @@ BOARD_HTML = r"""
     align-content:start;
   }
 
+  .section::after {
+    content:"";
+    position:absolute;
+    top:0;
+    bottom:0;
+    left:calc(var(--layout-left) + 6px);
+    width:1px;
+    background:rgba(255,255,255,.3);
+    opacity:.65;
+    pointer-events:none;
+  }
+
   .section .verse { grid-area: verse; }
   .section .todo { grid-area: todo; }
   .section .bus { grid-area: bus; }
   .section .home { grid-area: home; }
   .section .weather { grid-area: weather; }
 
-  .blk { background:rgba(0,0,0,.35); border:1px solid rgba(255,255,255,.08); border-radius:12px; padding:10px 12px; }
+  .blk { background:rgba(0,0,0,.35); border:1px solid rgba(255,255,255,.08); border-radius:12px; padding:16px 18px; }
   .blk h3 { margin:0 0 6px 0; font-size:16px; opacity:.95; text-shadow:0 0 6px rgba(0,0,0,.65);}
 
-.todo{ display:flex; flex-direction:column; height:100%; }
+.todo{ display:flex; flex-direction:column; height:100%; min-height:170px; }
   .todo .rows { display:grid; grid-template-columns: 1fr 1fr; gap:8px; flex:1 1 auto; }
   .todo .col { display:flex; flex-direction:column; gap:6px; min-width:0; }
   .todo .item { display:flex; justify-content:flex-start; gap:10px; font-size:14px; }
   .todo .title { flex:1 1 auto; white-space:nowrap; overflow:hidden; text-overflow:ellipsis; }
   .todo .due { opacity:.9; min-width:50px; margin-right:12px; }
 
-  .bus{display:flex; flex-direction:column; padding:0; background:transparent; border:none; height:100%;}
-  .bus .arrivals{display:flex; flex-direction:column; background:rgba(0,0,0,.28); border-radius:12px; padding:12px 14px; border:1px solid rgba(255,255,255,.12); min-width:0; flex:1 1 auto;}
-  .bus .arrivals h3{margin-bottom:6px;}
+  .bus{display:flex; flex-direction:column; gap:10px; background:rgba(0,0,0,.28); border:1px solid rgba(255,255,255,.12); border-radius:12px; padding:16px 18px; height:100%; min-height:190px; margin-top:8px;}
+  .bus .arrivals{display:flex; flex-direction:column; gap:8px; min-width:0; flex:1 1 auto;}
+  .bus .arrivals h3{margin-bottom:0;}
   .bus .stop{font-size:14px; margin-bottom:4px;}
   .bus .rows{display:flex; gap:10px; overflow:hidden;}
   .bus .col{flex:1 1 50%; display:flex; flex-direction:column; gap:6px;}
@@ -1735,7 +1748,7 @@ BOARD_HTML = r"""
   .bus .item .hops{width:6ch; text-align:right; margin-right:4px; white-space:nowrap;}
   .bus .item .msg{flex:0 0 6ch; text-align:right; opacity:.9; overflow:hidden; text-overflow:ellipsis; white-space:nowrap;}
 
-  .home{display:flex; flex-direction:column; background:rgba(0,0,0,.28); border:1px solid rgba(255,255,255,.12); border-radius:12px; padding:12px 14px; min-height:0;}
+  .home{display:flex; flex-direction:column; background:rgba(0,0,0,.28); border:1px solid rgba(255,255,255,.12); border-radius:12px; padding:20px 22px; min-height:360px;}
   .home h3{margin-bottom:6px;}
   .home .ha-grid{display:grid; grid-template-columns:repeat(6,minmax(0,1fr)); gap:8px; flex:1 1 auto; align-content:start;}
   .home .ha-device{display:flex; flex-direction:column; gap:4px; align-items:center; justify-content:center; padding:10px 6px; border-radius:12px; background:rgba(255,255,255,.08); border:1px solid rgba(255,255,255,.12); transition:background .2s, border-color .2s, box-shadow .2s, transform .2s; cursor:pointer; user-select:none;}


### PR DESCRIPTION
## Summary
- shrink the left column and add a vertical divider to better match the requested composition
- enlarge the todo, bus, and home control blocks with consistent padding and spacing
- set minimum heights so the todo and bus sections no longer crowd one another

## Testing
- not run (missing third-party dependencies)


------
https://chatgpt.com/codex/tasks/task_e_68d8f3dce43c83299c4e0fceea83ef60