### PR TITLE
Adjust bottom section layout spacing

### DIFF
--- a/scal_full_integrated.py
+++ b/scal_full_integrated.py
@@ -1694,12 +1694,13 @@ BOARD_HTML = r"""
 
   .section {
     position:relative;
-    height: calc(var(--H) - var(--top) - var(--cal));
+    min-height: calc(var(--H) - var(--top) - var(--cal));
+    height:auto;
     padding:10px 24px;
     box-sizing:border-box;
     display:grid;
     grid-template-columns: minmax(0, var(--layout-left)) minmax(0, 1fr);
-    grid-template-rows: auto minmax(0, 1fr) minmax(0, 1fr) auto;
+    grid-template-rows: auto auto auto auto;
     grid-template-areas:
       "verse verse"
       "todo home"


### PR DESCRIPTION
## Summary
- allow the dashboard section grid to grow taller instead of forcing a fixed height
- switch the grid rows to auto sizing so each block keeps its own space

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d929fa4bb48329912c3937aa5f2040