### PR TITLE
Configure Google Home credentials

### DIFF
--- a/scal_full_integrated.py
+++ b/scal_full_integrated.py
@@ -30,8 +30,8 @@ EMBEDDED_CONFIG = r"""{
     }
   },
   "google_home": {
-    "agent_user_id": "",
-    "service_account_file": "google_home_service_account.json"
+    "agent_user_id": "mangkoog@gmail.com",
+    "service_account_file": "/root/scal/google_home_service_account.json"
   },
   "todoist": {
     "api_token": "0aa4d2a4f95e952a1f635c14d6c6ba7e3b26bc2b",


### PR DESCRIPTION
## Summary
- set the Google Home agent user ID to mangkoog@gmail.com
- point the Google Home service account configuration to /root/scal/google_home_service_account.json

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d9b5e8bcb4832994ddfa18aaba0128